### PR TITLE
prebuild repo using scripts and node-gyp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ deps/*
 .DS_Store
 
 .vscode
+prebuilds/

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Copyright (c) 2016 Blizzard Entertainment.
 
 [![npm version](https://badge.fury.io/js/node-rdkafka.svg)](https://badge.fury.io/js/node-rdkafka)
 
-# Front - Foundations
+# Front
 
 Doc: [Prebuild Node-rdkafka Learnings](https://docs.google.com/document/d/1Xt22ieNMptySOzUklxicPuTr_5Pzlt8rks_ZwMJuYA4/edit#heading=h.b5eibbu0cqtd)
+
+The motivation for this fork is to create prebuilds and instantly install node-rdkafka when injected as a node_module.
 
 **How to create prebuilds:** npm run prebuilds
 1. Runs node-gyp rebuild to build from source

--- a/README.md
+++ b/README.md
@@ -13,15 +13,19 @@ Copyright (c) 2016 Blizzard Entertainment.
 
 Doc: [Prebuild Node-rdkafka Learnings](https://docs.google.com/document/d/1Xt22ieNMptySOzUklxicPuTr_5Pzlt8rks_ZwMJuYA4/edit#heading=h.b5eibbu0cqtd)
 
-The motivation for this fork is to create prebuilds and instantly install node-rdkafka when injected as a node_module.
+Node Package: [node-rdkafka](https://github.com/orgs/frontapp/packages/npm/package/node-rdkafka)
 
-**How to create prebuilds:** npm run prebuilds
-1. Runs node-gyp rebuild to build from source
-2. Tarballs /build and stores in /prebuilds
+Current Node Version: **v20.11.0**
 
-**How to install files:** npm install
-1. Searches for files in /build or proper prebuild platform + arch + ABI in /prebuilds
-2. Will default to node-gyp rebuild if no prebuilds found
+The motivation for this fork is to create prebuilds to instantly install node-rdkafka at build time.
+
+**How to create prebuilds:** *npm run prebuilds*
+1. Runs *node-gyp rebuild* to build from source
+2. Tarballs */build* and stores in */prebuilds*
+
+**How to install files:** *npm install*
+1. Searches for files in */build* or proper prebuild platform + arch + ABI in */prebuilds*
+2. Will default to *node-gyp rebuild* if no prebuilds found
 
 **Caveats:**
 1. The existing solution only works on MacOS, we will need to put in work to extend to Linux and/or Windows machines

--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ Copyright (c) 2016 Blizzard Entertainment.
 
 [![npm version](https://badge.fury.io/js/node-rdkafka.svg)](https://badge.fury.io/js/node-rdkafka)
 
+# Front - Foundations
+
+Doc: [Prebuild Node-rdkafka Learnings](https://docs.google.com/document/d/1Xt22ieNMptySOzUklxicPuTr_5Pzlt8rks_ZwMJuYA4/edit#heading=h.b5eibbu0cqtd)
+
+**How to create prebuilds:** npm run prebuilds
+1. Runs node-gyp rebuild to build from source
+2. Tarballs /build and stores in /prebuilds
+
+**How to install files:** npm install
+1. Searches for files in /build or proper prebuild platform + arch + ABI in /prebuilds
+2. Will default to node-gyp rebuild if no prebuilds found
+
+**Caveats:**
+1. The existing solution only works on MacOS, we will need to put in work to extend to Linux and/or Windows machines
+2. Can only create prebuilds using the current platform + architecture + node version
+
 # Looking for Collaborators!
 
 I am looking for *your* help to make this project even better! If you're interested, check [this out](https://github.com/Blizzard/node-rdkafka/issues/628)

--- a/binding.gyp
+++ b/binding.gyp
@@ -97,15 +97,10 @@
                     [
                       'OS=="mac"',
                       {
-                        'link_settings': {
-                          'ldflags': [
-                            '-Wl,-rpath,@loader_path/../deps'
-                          ],
-                          'libraries': [
-                            '../build/deps/librdkafka.dylib',
-                            '../build/deps/librdkafka++.dylib',
-                          ],
-                        },
+                        "libraries": [
+                          "../build/deps/librdkafka.dylib",
+                          "../build/deps/librdkafka++.dylib",
+                        ],
                       }
                     ]
                   ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -100,7 +100,7 @@
                         "libraries": [
                           "../build/deps/librdkafka.dylib",
                           "../build/deps/librdkafka++.dylib",
-                          "-Wl,-rpath='./build/deps'",
+                          "-Wl,-rpath,./build/deps",
                         ],
                       }
                     ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -100,7 +100,7 @@
                         "libraries": [
                           "../build/deps/librdkafka.dylib",
                           "../build/deps/librdkafka++.dylib",
-                          "-Wl,-rpath,./build/deps",
+                          "-Wl,-rpath,'$$ORIGIN/../deps'",
                         ],
                       }
                     ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -97,15 +97,15 @@
                     [
                       'OS=="mac"',
                       {
-                        'xcode_settings': {
-                          'OTHER_LDFLAGS': [
+                        'link_settings': {
+                          'ldflags': [
                             '-Wl,-rpath,@loader_path/../deps'
                           ],
+                          'libraries': [
+                            '../build/deps/librdkafka.dylib',
+                            '../build/deps/librdkafka++.dylib',
+                          ],
                         },
-                        "libraries": [
-                          "../build/deps/librdkafka.dylib",
-                          "../build/deps/librdkafka++.dylib",
-                        ],
                       }
                     ]
                   ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -97,10 +97,14 @@
                     [
                       'OS=="mac"',
                       {
+                        'xcode_settings': {
+                          'OTHER_LDFLAGS': [
+                            '-Wl,-rpath,@loader_path/../deps'
+                          ],
+                        },
                         "libraries": [
                           "../build/deps/librdkafka.dylib",
                           "../build/deps/librdkafka++.dylib",
-                          "-Wl,-rpath,@loader_path/../deps",
                         ],
                       }
                     ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -98,9 +98,9 @@
                       'OS=="mac"',
                       {
                         "libraries": [
+                          "-Wl,-rpath,'$$ORIGIN/../deps'",
                           "../build/deps/librdkafka.dylib",
                           "../build/deps/librdkafka++.dylib",
-                          "-Wl,-rpath,'$$ORIGIN/../deps'",
                         ],
                       }
                     ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -98,7 +98,7 @@
                       'OS=="mac"',
                       {
                         "libraries": [
-                          "-Wl,-rpath,'$$ORIGIN/../deps'",
+                          "-Wl,-rpath,@loader_path/../deps",
                           "../build/deps/librdkafka.dylib",
                           "../build/deps/librdkafka++.dylib",
                         ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -100,7 +100,30 @@
                         "libraries": [
                           "../build/deps/librdkafka.dylib",
                           "../build/deps/librdkafka++.dylib",
+                          "-Wl,-rpath,@loader_path/../deps",
                         ],
+                        "postbuilds": [
+                          {
+                            "postbuild_name": "Change librdkafka.1.dylib load path",
+                            "action": [
+                              "install_name_tool", 
+                              "-change", 
+                              "<(module_root_dir)/build/deps/librdkafka.1.dylib", 
+                              "@rpath/librdkafka.1.dylib", 
+                              "<(module_root_dir)/build/Release/node-librdkafka.node"
+                            ]
+                          },
+                          {
+                            "postbuild_name": "Change librdkafka++.1.dylib load path",
+                            "action": [
+                              "install_name_tool", 
+                              "-change", 
+                              "<(module_root_dir)/build/deps/librdkafka++.1.dylib", 
+                              "@rpath/librdkafka++.1.dylib", 
+                              "<(module_root_dir)/build/Release/node-librdkafka.node"
+                            ]
+                          }
+                        ]
                       }
                     ]
                   ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -98,9 +98,9 @@
                       'OS=="mac"',
                       {
                         "libraries": [
-                          "-Wl,-rpath,@loader_path/../deps",
                           "../build/deps/librdkafka.dylib",
                           "../build/deps/librdkafka++.dylib",
+                          "-Wl,-rpath,@loader_path/../deps",
                         ],
                       }
                     ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -100,6 +100,7 @@
                         "libraries": [
                           "../build/deps/librdkafka.dylib",
                           "../build/deps/librdkafka++.dylib",
+                          "-Wl,-rpath='./build/deps'",
                         ],
                       }
                     ]

--- a/ci/on-install.js
+++ b/ci/on-install.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const { spawn } = require('child_process');
+const { exit } = require('process');
 
 async function main() {
   if (fs.existsSync('./build')) {
@@ -18,9 +19,10 @@ async function main() {
       `./prebuild/${prebuildFileName}.tar.gz`
     ]);
     tarCmd.stdout.pipe(process.stdout);
-    tarCmd.stderr.pipe(process.stderr)
+    tarCmd.stderr.pipe(process.stderr);
   } else {
-    throw new Error(`Missing node-rdkafka for arch "${process.arch}" and ABI "${process.versions.modules}". Prebuild bindings first.`);
+    process.stdout.write(`Missing node-rdkafka for arch "${process.arch}" and ABI "${process.versions.modules}". Prebuild bindings first.`);
+    exit(1);
   }
 }
 

--- a/ci/on-install.js
+++ b/ci/on-install.js
@@ -8,20 +8,19 @@ async function main() {
     return;
   }
 
-  const prebuildFileName = `platform-${process.arch}-ABI-${process.versions.modules}`;
-  const prebuildFilePath = `./prebuild/${prebuildFileName}.tar.gz`;
-
+  const prebuildFileName = `${process.platform}-${process.arch}-ABI-${process.versions.modules}`;
+  const prebuildFilePath = `./prebuilds/${prebuildFileName}.tar.gz`;
 
   if (fs.existsSync(prebuildFilePath)) {
     process.stdout.write(`-- Unpacking "${prebuildFilePath}" archive...\n`);
     const tarCmd = spawn('tar', [
       'xzvf',
-      `./prebuild/${prebuildFileName}.tar.gz`
+      `${prebuildFilePath}`
     ]);
     tarCmd.stdout.pipe(process.stdout);
     tarCmd.stderr.pipe(process.stderr);
   } else {
-    process.stdout.write(`Missing node-rdkafka for arch "${process.arch}" and ABI "${process.versions.modules}". Prebuild bindings first.`);
+    process.stdout.write(`Missing node-rdkafka for ${prebuildFilePath}". Building from source.`);
     exit(1);
   }
 }

--- a/ci/on-install.js
+++ b/ci/on-install.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const { spawn } = require('child_process');
+
+async function main() {
+  if (fs.existsSync('./build')) {
+    process.stdout.write('-- node-rdkafka bindings already installed, skipping\n');
+    return;
+  }
+
+  const prebuildFileName = `platform-${process.arch}-ABI-${process.versions.modules}`;
+  const prebuildFilePath = `./prebuild/${prebuildFileName}.tar.gz`;
+
+
+  if (fs.existsSync(prebuildFilePath)) {
+    process.stdout.write(`-- Unpacking "${prebuildFilePath}" archive...\n`);
+    const tarCmd = spawn('tar', [
+      'xzvf',
+      `./prebuild/${prebuildFileName}.tar.gz`
+    ]);
+    tarCmd.stdout.pipe(process.stdout);
+    tarCmd.stderr.pipe(process.stderr)
+  } else {
+    throw new Error(`Missing node-rdkafka for arch "${process.arch}" and ABI "${process.versions.modules}". Prebuild bindings first.`);
+  }
+}
+
+main().catch(err => console.error(err));

--- a/ci/on-prebuild.js
+++ b/ci/on-prebuild.js
@@ -2,12 +2,13 @@ const fs = require('fs');
 const { spawn } = require('child_process');
 
 async function main() {
-  const prebuildFileName = `platform-${process.arch}-ABI-${process.versions.modules}`;
+  const prebuildFileName = `${process.platform}-${process.arch}-ABI-${process.versions.modules}`;
+  const prebuildFilePath = `./prebuilds/${prebuildFileName}.tar.gz`;
 
-  process.stdout.write(`Preparing "./prebuild/${prebuildFileName}.tar.gz" archive...\n`);
+  process.stdout.write(`Preparing "./prebuilds/${prebuildFileName}.tar.gz" archive...\n`);
   const tarCmd = spawn('tar', [
     'czvf',
-    `./prebuild/${prebuildFileName}.tar.gz`,
+    `${prebuildFilePath}`,
     './build',
   ]);
   tarCmd.stdout.pipe(process.stdout);

--- a/ci/on-prebuild.js
+++ b/ci/on-prebuild.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const { spawn } = require('child_process');
+
+async function main() {
+  const prebuildFileName = `platform-${process.arch}-ABI-${process.versions.modules}`;
+
+  process.stdout.write(`Preparing "./prebuild/${prebuildFileName}.tar.gz" archive...\n`);
+  const tarCmd = spawn('tar', [
+    'czvf',
+    `./prebuild/${prebuildFileName}.tar.gz`,
+    './build',
+  ]);
+  tarCmd.stdout.pipe(process.stdout);
+  tarCmd.stderr.pipe(process.stderr)
+}
+
+main().catch(err => console.error(err));

--- a/configure
+++ b/configure
@@ -10,6 +10,6 @@ scriptdir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 
 pushd ./deps/librdkafka &> /dev/null
 
-./configure --prefix="${scriptdir}/build/deps" --libdir="${scriptdir}/build/deps" $*
+./configure --prefix="${scriptdir}/build/deps" --libdir="${scriptdir}/build/deps" --install-deps --source-deps-only --enable-static $*
 
 popd &> /dev/null

--- a/configure
+++ b/configure
@@ -10,6 +10,6 @@ scriptdir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 
 pushd ./deps/librdkafka &> /dev/null
 
-./configure --prefix="${scriptdir}/build/deps" --libdir="${scriptdir}/build/deps" --install-deps --source-deps-only --enable-static $*
+./configure --prefix="${scriptdir}/build/deps" --libdir="${scriptdir}/build/deps" $*
 
 popd &> /dev/null

--- a/errors.d.ts
+++ b/errors.d.ts
@@ -128,10 +128,8 @@ export const CODES: { ERRORS: {
   ERR__AUTO_OFFSET_RESET: number,
   /** Partition log truncation detected (**-139**) */
   ERR__LOG_TRUNCATION: number,
-
   /** End internal error codes (**-100**) */
   ERR__END: number,
-
   /* Kafka broker errors: */
   /** Unknown broker error (**-1**) */
   ERR_UNKNOWN: number,

--- a/lib/error.js
+++ b/lib/error.js
@@ -158,10 +158,8 @@ LibrdKafkaError.codes = {
   ERR__AUTO_OFFSET_RESET: -140,
   /** Partition log truncation detected */
   ERR__LOG_TRUNCATION: -139,
-
   /** End internal error codes */
   ERR__END: -100,
-
   /* Kafka broker errors: */
   /** Unknown broker error */
   ERR_UNKNOWN: -1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "node-rdkafka",
+  "name": "@frontapp/node-rdkafka",
   "version": "v2.16.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "node-rdkafka",
+      "name": "@frontapp/node-rdkafka",
       "version": "v2.16.1",
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-rdkafka",
+  "name": "@frontapp/node-rdkafka",
   "version": "v2.16.1",
   "description": "Node.js bindings for librdkafka",
   "librdkafka": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:Blizzard/node-rdkafka.git"
+    "url": "git@github.com:frontapp/node-rdkafka.git"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "configure": "node-gyp configure",
     "build": "node-gyp build",
+    "prebuilds": "node-gyp rebuild && node ./ci/on-prebuild.js",
     "test": "make test",
-    "install": "node-gyp rebuild",
+    "install": "node ./ci/on-install.js",
     "prepack": "node ./ci/prepublish.js"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "node-gyp build",
     "prebuilds": "node-gyp rebuild && node ./ci/on-prebuild.js",
     "test": "make test",
-    "install": "node ./ci/on-install.js",
+    "install": "node ./ci/on-install.js || node-gyp rebuild",
     "prepack": "node ./ci/prepublish.js"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   },
   "engines": {
     "node": ">=6.0.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
   }
 }


### PR DESCRIPTION
Doc: [Prebuild Node-rdkafka Learnings](https://docs.google.com/document/d/1Xt22ieNMptySOzUklxicPuTr_5Pzlt8rks_ZwMJuYA4/edit#heading=h.b5eibbu0cqtd)

Node Package: [node-rdkafka](https://github.com/orgs/frontapp/packages/npm/package/node-rdkafka)

Current Node Version: v20.11.0

The motivation for this fork is to create prebuilds to instantly install node-rdkafka at build time.

How to create prebuilds: npm run prebuilds
1. Runs node-gyp rebuild to build from source
2. Tarballs /build and stores in /prebuilds

How to install files: npm install
1. Searches for files in /build or proper prebuild platform + arch + ABI in /prebuilds
2. Will default to node-gyp rebuild if no prebuilds found

Caveats:
1. The existing solution only works on MacOS, we will need to put in work to extend to Linux and/or Windows machines
2. Can only create prebuilds using the current platform + architecture + node version